### PR TITLE
Add gitfleximod and .gitmodules for CTSM tools that are needed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,52 @@
+# This is a git submodule file with additional support for
+# # git-fleximod (https://github.com/ESMCI/git-fleximod)
+# #
+# # The additional flags supported by git-fleximod are
+# # fxtag - the tag associated with the submodule, this tag can be tested for
+# #         consistancy with the submodule hash using git-fleximod status
+# #         the hash can be updated to the tag using git-fleximod update
+# #
+# # fxrequired - indicates if a given submodule should be checked out on install
+# #              submoudules can be toplevel or internal and required or optional
+# #              toplevel means that the submodule should only be checked out if the
+# #              module is the toplevel of the git repo (is not a submodule itself)
+# #              internal means that the submodule is needed by the component whether
+# #              the component is toplevel or the submodule of another repo
+# #              required means that the submodule should always be checked out
+# #              optional means that the submodule should only be checked out if the
+# #              optional flag is provided to git-fleximod or the submodule name is
+# #              explicitly listed on the git-fleximod command line.
+# #
+# # fxsparse -   this is a path to a git sparse checkout file indicating that the
+# #              submodule should be checked out in sparse mode
+# #
+# # fxDONOTUSEurl    -   this field is used by git-fleximod test to insure that the url is pointing
+# #              to the official url of the repo and not to an unofficial fork.
+# #              It is intended for use of github workflows to test commits to protected
+# #              repository branches.
+# #
+
+[submodule "ctsm"]
+path = code/land-use/ctsm5.4_for_mksurfdat
+url = https://github.com/ESCOMP/CTSM
+fxtag = alpha-ctsm5.4.CMIP7.11.ctsm5.3.075
+fxrequired = ToplevelRequired
+# Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
+#fxDONOTUSEurl = https://github.com/ESCOMP/CTSM
+
+
+[submodule "ccs_config"]
+path = code/land-use/ctsm5.4_for_mksurfdat/ccs_config
+url = https://github.com/ESMCI/ccs_config_cesm.git
+fxtag = ccs_config_cesm1.0.56
+fxrequired = ToplevelRequired
+# Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
+# fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
+#
+[submodule "cime"]
+path = code/land-use/ctsm5.4_for_mksurfdat/cime
+url = https://github.com/ESMCI/cime
+fxtag = cime6.1.113
+fxrequired = ToplevelRequired
+# # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
+# fxDONOTUSEurl = https://github.com/ESMCI/cime

--- a/code/co2-isotopes/README.txt
+++ b/code/co2-isotopes/README.txt
@@ -1,1 +1,0 @@
-Add instructions 


### PR DESCRIPTION
Add the git-fleximod subtree so that it can be used to maintain submodules that are needed.

Add an .gitmodules file with some of the CTSM tools needed.